### PR TITLE
cmd/compile: Fix riscv ginsnop() to generate ADDI $0, ZERO

### DIFF
--- a/src/cmd/compile/internal/riscv/gsubr.go
+++ b/src/cmd/compile/internal/riscv/gsubr.go
@@ -13,6 +13,8 @@ import (
 func ginsnop() {
 	// Hardware nop is ADD $0, ZERO
 	p := gc.Prog(riscv.AADD)
-	p.To.Type = obj.TYPE_REG
-	p.To.Reg = riscv.REG_ZERO
+	p.From.Type = obj.TYPE_CONST
+	p.From.Offset = 0
+	p.From3 = &obj.Addr{Type: obj.TYPE_REG, Reg: riscv.REG_ZERO}
+	p.To = *p.From3
 }


### PR DESCRIPTION
ginsnop() used to generate ADD ZERO, ZERO. The actual NOP defined
is an ADDI instruction. This commit fixes the NOP generation, and
generates a ADDI $0, ZERO, ZERO